### PR TITLE
Can pass classes to buttons to assist with styling

### DIFF
--- a/jquery-impromptu.js
+++ b/jquery-impromptu.js
@@ -83,7 +83,7 @@
 	                    states += ' name="' + $.prompt.options.prefix + '_' + statename + '_button' + v.title.replace(/[^a-z0-9]+/gi,'') + '" id="' + $.prompt.options.prefix + '_' + statename + '_button' + v.title.replace(/[^a-z0-9]+/gi,'') + '" value="' + v.value + '">' + v.title + '</button>';
 	
 	                } else {
-	                    //states += '<button name="' + $.prompt.options.prefix + '_' + statename + '_button' + k + '" id="' + $.prompt.options.prefix +  '_' + statename + '_button' + k + '" value="' + v + '">' + k + '</button>';
+	                    states += '<button name="' + $.prompt.options.prefix + '_' + statename + '_button' + k + '" id="' + $.prompt.options.prefix +  '_' + statename + '_button' + k + '" value="' + v + '">' + k + '</button>';
 	                    
 	                }
 	            });


### PR DESCRIPTION
Hi,

I've added the ability to pass an array of 'classes' alongside a button to be used to style the button. This is helpful for using improptu within another css framework (like so http://twitter.github.com/bootstrap/components.html) and having everything themed consistently. 

You would pass your buttons in the same way as in example 18 on your demo page...

```
buttons:[
        {title: 'Hello World',value:true, classes: ['button', 'icon', 'confirm', 'primary']},
        {title: 'Good Bye',value:false, , classes: ['button', 'secondary', 'warning']}
], 
```
