### PR TITLE
jqif position: absolute to position: fixed

### DIFF
--- a/jquery-impromptu.js
+++ b/jquery-impromptu.js
@@ -327,7 +327,7 @@
 			bottom: 0
 		});
 		$.prompt.jqif.css({
-			position: "absolute",
+			position: "fixed",
 			height: height,
 			width: "100%",
 			top: 0,


### PR DESCRIPTION
When Overlay is extended (FAQs for example) and the height of the overlay is greater than the window height, then the overlay does not cover that part of the window.
