### PR TITLE
Ensure width is not greater than page

### DIFF
--- a/src/jquery-impromptu.css
+++ b/src/jquery-impromptu.css
@@ -3,7 +3,8 @@
 	background-color: #777777; 
 }
 div.jqi{ 
-	width: 400px; 
+	width: 400px;
+	max-width:90%;
 	font-family: Verdana, Geneva, Arial, Helvetica, sans-serif; 
 	position: absolute; 
 	background-color: #ffffff; 


### PR DESCRIPTION
On an iPhone 5 in portrait mode, with the `viewport` meta tag set to `"width=device-width"`, the modal clips off the screen with no scroll-bar. Unless the persistent option is disabled, this also creates a useability problem because the close button also clips off the screen.
