### PR TITLE
Prevent overlapping the buttons

### DIFF
--- a/dist/jquery-impromptu.css
+++ b/dist/jquery-impromptu.css
@@ -6,7 +6,7 @@
 	background-color: #777777; 
 }
 div.jqi{ 
-	width: 400px; 
+	min-width: 400px; 
 	max-width:90%;
 	font-family: Verdana, Geneva, Arial, Helvetica, sans-serif; 
 	position: absolute; 


### PR DESCRIPTION
Example:

``` (javascript)
$.prompt('<img src="http://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg" style="float:right" />text');
```

The second issue example:

``` (javascript)
$.prompt('text',{buttons:{'Button 1':true, 'Button 2 long':true, 'Button 3 very loooooooooooooooooooong':true}});
```
