### PR TITLE
State Position Function

### DIFF
--- a/src/jquery-impromptu.js
+++ b/src/jquery-impromptu.js
@@ -433,14 +433,15 @@
 				arrow = '',
 				title = '',
 				opts = t.options,
+				pos = $.isFunction(stateobj.position) ? stateobj.position() : stateobj.position,
 				$jqistates = t.jqi.find('.'+ opts.prefix +'states'),
 				buttons = [],
 				showHtml,defbtn,k,v,l,i=0;
 
 			stateobj = $.extend({},Imp.defaults.state, {name:statename}, stateobj);
 
-			if(stateobj.position.arrow !== null){
-				arrow = '<div class="'+ opts.prefix + 'arrow '+ opts.prefix + 'arrow'+ stateobj.position.arrow +'"></div>';
+			if($.isPlainObject(pos) && pos.arrow !== null){
+				arrow = '<div class="'+ opts.prefix + 'arrow '+ opts.prefix + 'arrow'+ pos.arrow +'"></div>';
 			}
 			if(stateobj.title && stateobj.title !== ''){
 				title = '<div class="lead '+ opts.prefix + 'title '+ opts.classes.title +'">'+  stateobj.title +'</div>';
@@ -627,7 +628,7 @@
 				restoreFx = $.fx.off,
 				$state = t.getCurrentState(),
 				stateObj = t.options.states[$state.data('jqi-name')],
-				pos = stateObj? stateObj.position : undefined,
+				pos = stateObj ? $.isFunction(stateObj.position) ? stateObj.position() : stateObj.position : undefined,
 				$window = $(window),
 				bodyHeight = document.body.scrollHeight, //$(document.body).outerHeight(true),
 				windowHeight = $(window).height(),


### PR DESCRIPTION
state.position can now be a function which returns an object, e.g.

```
var states = [
    {
        title: 'Some Title',
        html: 'Some message',
        buttons: { Next: 1 },
        position: function() {
            return {
                container: '#someContainer',
                x: $someContainer.width() / 2,
                y: $someContainer.height(),
                width: 200,
                arrow: 'tl'
            }
        },
        submit: submitFunc
    }
];
```

This has some benefits such as possible prompt x and y recalculation on window resize. In the above example, the prompt would move relative to changes in the height an width of `$someContainer` on window resize.
